### PR TITLE
chore: .claude/settings.local.json を gitignore に追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "mcp__acp__Bash",
-      "mcp__acp__Edit",
-      "mcp__acp__Write"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ epubcheck-5.1.0/
 backup/
 
 input.ltjruby
+
+# Claude Code local settings
+.claude/settings.local.json


### PR DESCRIPTION
## 概要

ローカル環境固有の Claude Code 権限設定 `.claude/settings.local.json` を `.gitignore` に追加し、リポジトリの追跡から外します。

## 変更

- `.gitignore` に `.claude/settings.local.json` を追加
- `git rm --cached` で追跡解除(ローカルファイルは保持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)